### PR TITLE
Allow flexible metadata fields in NodeDump

### DIFF
--- a/service/service/tana_types.py
+++ b/service/service/tana_types.py
@@ -25,8 +25,11 @@ class Props(BaseModel):
 class NodeDump(BaseModel):
   id: str
   props: Props
-  touchCounts: Optional[List[int]] = None
-  modifiedTs: Optional[List[int]] = None
+  # These rarely used metadata fields may appear in multiple formats
+  # (lists, dicts, or even JSON-encoded strings). Accept broad types to avoid
+  # validation errors when importing Tana exports.
+  touchCounts: Optional[Union[List[int], Dict[str, int], str]] = None
+  modifiedTs: Optional[Union[List[int], Dict[str, int], str]] = None
   children: Optional[List[str]] = None
   associationMap: Optional[Dict[str, str]] = None
   underConstruction: Optional[bool] = None


### PR DESCRIPTION
## Summary
- Accept lists, dicts, or JSON strings for rarely used `touchCounts` and `modifiedTs` metadata fields to handle diverse Tana export formats

## Testing
- `PYTHONPATH=service python -m pytest service/tests -q` *(fails: ConnectionError to localhost:8000)*

------
https://chatgpt.com/codex/tasks/task_b_68bbecf25210832e82b0c86881e41c20