### PR TITLE
fix: remove webapp package copy step

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -7,7 +7,6 @@
     "type": "git",
     "url": "https://github.com/verveguy/tana-helper"
   },
-  "private": false,
   "dependencies": {
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11.10.6",
@@ -34,7 +33,7 @@
     "xterm-addon-fit": "^0.8.0"
   },
   "scripts": {
-    "build": "rimraf dist && node esbuild.config.mjs && cp -rp dist/* ../service/service/dist",
+    "build": "rimraf dist && node esbuild.config.mjs",
     "watch": "watch 'yarn build' ./src"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Summary
- avoid `cp` errors during webapp build by removing the copy from `package.json`

## Testing
- `bash release/build.sh` *(fails: There is no tracking information for the current branch)*
- `bash webapp/build.sh`


------
https://chatgpt.com/codex/tasks/task_b_68bc0b9869ac832ebe52c711caa760d9