### PR TITLE
Add legend for tag colors in visualizer

### DIFF
--- a/docs/README_VISUALIZER.md
+++ b/docs/README_VISUALIZER.md
@@ -2,7 +2,9 @@
 
 Inspired by the marketing visualization on the Tana.inc website, `tana-helper` provides a 3D visualization of your Tana workspace.
 
-Check out this [video demo](https://share.cleanshot.com/VY0zm55s) and this 
+Check out this [video demo](https://share.cleanshot.com/VY0zm55s) and this
+
+The visualizer displays nodes in the color of their associated tags and now includes a legend explaining the color assignments.
 
 ## Building
 

--- a/webapp/src/components/ColorLegend.tsx
+++ b/webapp/src/components/ColorLegend.tsx
@@ -1,0 +1,42 @@
+import React, { useContext, useMemo } from "react";
+import { TanaHelperContext } from "../TanaHelperContext";
+import './Visualizer.css';
+
+const IS_TAG_LINK = 'itl';
+
+export default function ColorLegend() {
+  const { graphData } = useContext(TanaHelperContext);
+
+  const items = useMemo(() => {
+    if (!graphData) return [];
+    const tagIds = new Set<string>();
+    graphData.links?.forEach((link: any) => {
+      const reason = link.reason;
+      if (reason === IS_TAG_LINK) {
+        const target = typeof link.target === 'object' ? link.target.id : link.target;
+        tagIds.add(target);
+      }
+    });
+    const legends: { color: string; name: string }[] = [];
+    graphData.nodes?.forEach((node: any) => {
+      if (tagIds.has(node.id) && node.color) {
+        legends.push({ color: node.color, name: node.name });
+      }
+    });
+    legends.sort((a, b) => a.name.localeCompare(b.name));
+    return legends;
+  }, [graphData]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="color-legend">
+      {items.map(item => (
+        <div className="legend-item" key={item.name}>
+          <span className="legend-color" style={{ backgroundColor: item.color }} />
+          <span>{item.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/components/Visualizer.css
+++ b/webapp/src/components/Visualizer.css
@@ -15,10 +15,38 @@
   width: 100%;
   padding: 0px;
   overflow: hidden;
+  position: relative;
 }
 
 /* This one is needed to house the fixed-size graph */
 .abs-container {
   position: absolute;
   height: inherit;
+}
+
+.color-legend {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 2px;
+}
+
+.legend-color {
+  width: 12px;
+  height: 12px;
+  border: 1px solid #fff;
+  margin-right: 4px;
+}
+
+.legend-item:last-child {
+  margin-bottom: 0;
 }

--- a/webapp/src/components/Visualizer.tsx
+++ b/webapp/src/components/Visualizer.tsx
@@ -13,6 +13,7 @@ import ForceGraph3D from 'react-force-graph-3d';
 import ForceGraph2D from 'react-force-graph-2d';
 import { TanaHelperContext } from "../TanaHelperContext";
 import { useDimensions } from "./utils";
+import ColorLegend from './ColorLegend';
 import './Visualizer.css';
 
 export default function Visualizer() {
@@ -55,6 +56,7 @@ export default function Visualizer() {
     // container is sized, and we need to know the size of the container to render the graph.
     return (
       <div className="graph-container" ref={containerRef}>
+        <ColorLegend />
         <div className="abs-container" >
           { twoDee ?
             <ForceGraph2D ref={fgRef}


### PR DESCRIPTION
## Summary
- display legend explaining node colors in Tana visualizer
- style legend overlay and document color behavior

## Testing
- `PYENV_VERSION=3.11.12 poetry run pytest` (fails: Connection refused to localhost)
- `yarn test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68bec863a1d4832e8574facda0454188